### PR TITLE
Default optimization level to 0.

### DIFF
--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -5,7 +5,7 @@ using Symbolica.Abstraction;
 using Symbolica.Computation;
 using Symbolica.Implementation;
 
-var bytes = await Serializer.Serialize(args[0], args.Last(a => a.StartsWith("--O")));
+var bytes = await Serializer.Serialize(args[0], args.LastOrDefault(a => a.StartsWith("--O")) ?? "--O0");
 var executor = new Executor(new ContextFactory(), new Options(
     args.Contains("--use-symbolic-garbage"),
     args.Contains("--use-symbolic-addresses"),


### PR DESCRIPTION
Now that we know a bit more about where `insertelement` and `extractelement` often come from we should probably default this to O0, at least until we either know more about how to scalarize them reliably or we implement vectors properly throughout.