### PR TITLE
Put an abort in the symbolize function to stop accidentally executing…

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -133,7 +133,7 @@ jobs:
           nugetPush: false
         - os: windows-2019
           setupScript: |
-            Invoke-WebRequest -Uri https://aka.ms/wsl-ubuntu-1804 -OutFile ubuntu.zip
+            Invoke-WebRequest -Uri https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu_1804.2019.522.0_x64.appx -OutFile ubuntu.zip
             Expand-Archive ubuntu.zip
             .\ubuntu\ubuntu1804.exe install --root
             wsl ./lib/install-bionic.sh
@@ -141,7 +141,7 @@ jobs:
           nugetPush: false
         - os: windows-2019
           setupScript: |
-            Invoke-WebRequest -Uri https://aka.ms/wslubuntu2004 -OutFile ubuntu.zip
+            Invoke-WebRequest -Uri https://wslstorestorage.blob.core.windows.net/wslblob/Ubuntu_2004.2020.424.0_x64.appx -OutFile ubuntu.zip
             Expand-Archive ubuntu.zip
             .\ubuntu\ubuntu2004.exe install --root
             wsl ./lib/install-focal.sh

--- a/lib/c/build/include/symbolica.h
+++ b/lib/c/build/include/symbolica.h
@@ -1,4 +1,5 @@
 #include <stddef.h>
+#include <stdlib.h>
 
 #define SYMBOLIZE(x) symbolize(&x, sizeof x, #x)
 
@@ -9,6 +10,7 @@ extern "C"
 
     void symbolize(void *address, size_t size, const char *name)
     {
+        abort();
     }
 
 #ifdef __cplusplus

--- a/src/Abstraction/StateError.cs
+++ b/src/Abstraction/StateError.cs
@@ -2,6 +2,7 @@
 {
     public enum StateError
     {
+        Abort,
         DivideByZero,
         FailingAssertion,
         InvalidJump,

--- a/src/Representation/DeclarationFactory.cs
+++ b/src/Representation/DeclarationFactory.cs
@@ -49,6 +49,7 @@ namespace Symbolica.Representation
         private static readonly IReadOnlyDictionary<string, Func<FunctionId, IParameters, IFunction>> Specials =
             new Dictionary<string, Func<FunctionId, IParameters, IFunction>>
             {
+                {"abort", (id, parameters) => new Abort(id, parameters)},
                 {"__assert_fail", (id, parameters) => new Fail(id, parameters)},
                 {"calloc", (id, parameters) => new AllocateAndClear(id, parameters)},
                 {"ceil", (id, parameters) => new Ceiling(id, parameters)},

--- a/src/Representation/Functions/Abort.cs
+++ b/src/Representation/Functions/Abort.cs
@@ -1,0 +1,21 @@
+﻿using Symbolica.Abstraction;
+
+namespace Symbolica.Representation.Functions
+{
+    internal sealed class Abort : IFunction
+    {
+        public Abort(FunctionId id, IParameters parameters)
+        {
+            Id = id;
+            Parameters = parameters;
+        }
+
+        public FunctionId Id { get; }
+        public IParameters Parameters { get; }
+
+        public void Call(IState state, ICaller caller, IArguments arguments)
+        {
+            throw new StateException(StateError.Abort, state.Space);
+        }
+    }
+}


### PR DESCRIPTION
… concretely.