### PR TITLE
Encapsulate assertions so minimal interface can be passed to values.

### DIFF
--- a/src/Computation/Assertions.cs
+++ b/src/Computation/Assertions.cs
@@ -1,0 +1,28 @@
+﻿using Symbolica.Computation.Values.Constants;
+using Symbolica.Expression;
+
+namespace Symbolica.Computation;
+
+internal sealed class Assertions : IAssertions
+{
+    private readonly IPersistentSpace _space;
+
+    public Assertions(IPersistentSpace space)
+    {
+        _space = space;
+    }
+
+    public IConstantValue GetConstant(IValue value)
+    {
+        using var constraints = _space.GetConstraints();
+
+        return ConstantUnsigned.Create(value.Size, constraints.Evaluate(value));
+    }
+
+    public IProposition GetProposition(IValue value)
+    {
+        return value is IConstantValue v
+            ? ConstantProposition.Create(_space, v)
+            : SymbolicProposition.Create(_space, value);
+    }
+}

--- a/src/Computation/Context.cs
+++ b/src/Computation/Context.cs
@@ -70,8 +70,7 @@ internal sealed class Context<TContextHandle> : IContext
         return Create(c => c.MkSolver(c.MkTactic("smt")));
     }
 
-    private TZ3Object Create<TZ3Object>(Func<Context, TZ3Object> func)
-        where TZ3Object : Z3Object
+    private TResult Create<TResult>(Func<Context, TResult> func)
     {
         return func(_contextHandle.Context);
     }

--- a/src/Computation/Expression.cs
+++ b/src/Computation/Expression.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Numerics;
 using Symbolica.Collection;
 using Symbolica.Computation.Exceptions;
-using Symbolica.Computation.Values.Constants;
 using Symbolica.Expression;
 
 namespace Symbolica.Computation;
@@ -32,14 +31,12 @@ internal sealed class Expression<TContext> : IExpression
     {
         return _value is IConstantValue
             ? this
-            : Evaluate((IPersistentSpace) space);
+            : Create(((IPersistentSpace) space).Assertions.GetConstant);
     }
 
     public IProposition GetProposition(ISpace space)
     {
-        return _value is IConstantValue v
-            ? ConstantProposition.Create(space, v)
-            : SymbolicProposition.Create((IPersistentSpace) space, _value);
+        return ((IPersistentSpace) space).Assertions.GetProposition(_value);
     }
 
     public IExpression Add(IExpression expression)
@@ -332,14 +329,6 @@ internal sealed class Expression<TContext> : IExpression
         using var context = new TContext();
 
         return _value.AsConstant(context);
-    }
-
-    private IExpression Evaluate(IPersistentSpace space)
-    {
-        using var constraints = space.GetConstraints();
-
-        return new Expression<TContext>(_collectionFactory,
-            ConstantUnsigned.Create(Size, constraints.Evaluate(_value)));
     }
 
     public static IExpression CreateSymbolic(ICollectionFactory collectionFactory,

--- a/src/Computation/IAssertions.cs
+++ b/src/Computation/IAssertions.cs
@@ -1,0 +1,9 @@
+﻿using Symbolica.Expression;
+
+namespace Symbolica.Computation;
+
+internal interface IAssertions
+{
+    IConstantValue GetConstant(IValue value);
+    IProposition GetProposition(IValue value);
+}

--- a/src/Computation/IPersistentSpace.cs
+++ b/src/Computation/IPersistentSpace.cs
@@ -4,6 +4,8 @@ namespace Symbolica.Computation;
 
 internal interface IPersistentSpace : ISpace
 {
+    IAssertions Assertions { get; }
+
     IPersistentSpace Assert(IValue assertion);
     IConstraints GetConstraints();
 }

--- a/src/Computation/PersistentSpace.cs
+++ b/src/Computation/PersistentSpace.cs
@@ -25,6 +25,7 @@ internal sealed class PersistentSpace<TContext> : IPersistentSpace
     }
 
     public Bits PointerSize { get; }
+    public IAssertions Assertions => new Assertions(this);
 
     public IPersistentSpace Assert(IValue assertion)
     {


### PR DESCRIPTION
As you can probably guess from how long it took, this isn't really the full glory I was going for, but it does give us the "correct" minimal `IAssertions` interface to pass into `Read` and `Write`.

I was really wanting to take `GetConstraints` off `IPersistentSpace` but I couldn't plumb it without making other things much more complicated or having a bunch of random classes and interfaces that don't have a sensible name, so probably don't really represent anything. It's fairly localized here so perhaps we can revisit soon when we have the important bits working.