### PR TITLE
Make all IValue implementations Records to get structural equality.

### DIFF
--- a/src/Computation/BitVector.cs
+++ b/src/Computation/BitVector.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation;
 
-internal abstract class BitVector : Integer
+internal abstract record BitVector : Integer
 {
     protected BitVector(Bits size)
         : base(size)

--- a/src/Computation/Bool.cs
+++ b/src/Computation/Bool.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation;
 
-internal abstract class Bool : Integer
+internal abstract record Bool : Integer
 {
     protected Bool()
         : base(Bits.One)
@@ -13,7 +13,7 @@ internal abstract class Bool : Integer
     public sealed override BitVecExpr AsBitVector(IContext context)
     {
         return context.CreateExpr(c => (BitVecExpr) c.MkITE(AsBool(context),
-            c.MkBV(new[] {true}),
-            c.MkBV(new[] {false})));
+            c.MkBV(new[] { true }),
+            c.MkBV(new[] { false })));
     }
 }

--- a/src/Computation/Float.cs
+++ b/src/Computation/Float.cs
@@ -4,7 +4,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation;
 
-internal abstract class Float : IValue
+internal abstract record Float : IValue
 {
     protected Float(Bits size)
     {

--- a/src/Computation/Integer.cs
+++ b/src/Computation/Integer.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation;
 
-internal abstract class Integer : IValue
+internal abstract record Integer : IValue
 {
     protected Integer(Bits size)
     {

--- a/src/Computation/NormalFloat.cs
+++ b/src/Computation/NormalFloat.cs
@@ -4,7 +4,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation;
 
-internal sealed class NormalFloat : Float
+internal sealed record NormalFloat : Float
 {
     private readonly string _value;
 
@@ -73,7 +73,7 @@ internal sealed class NormalFloat : Float
 
     private static (BigInteger, int) ParseNonNegativeDecimal(string value)
     {
-        var index = value.IndexOfAny(new[] {'e', 'E'});
+        var index = value.IndexOfAny(new[] { 'e', 'E' });
 
         return index == -1
             ? ParseStandardNonNegativeDecimal(value, 0)

--- a/src/Computation/Symbol.cs
+++ b/src/Computation/Symbol.cs
@@ -6,7 +6,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation;
 
-internal sealed class Symbol : BitVector
+internal sealed record Symbol : BitVector
 {
     private readonly IValue[] _assertions;
     private readonly string _name;

--- a/src/Computation/Values/Add.cs
+++ b/src/Computation/Values/Add.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class Add : BitVector
+internal sealed record Add : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/And.cs
+++ b/src/Computation/Values/And.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class And : BitVector
+internal sealed record And : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/ArithmeticShiftRight.cs
+++ b/src/Computation/Values/ArithmeticShiftRight.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class ArithmeticShiftRight : BitVector
+internal sealed record ArithmeticShiftRight : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/Constants/ConstantBitVector.cs
+++ b/src/Computation/Values/Constants/ConstantBitVector.cs
@@ -7,7 +7,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values.Constants;
 
-internal sealed class ConstantBitVector : BitVector, IConstantValue
+internal sealed record ConstantBitVector : BitVector, IConstantValue
 {
     private readonly IPersistentList<byte> _value;
 

--- a/src/Computation/Values/Constants/ConstantBool.cs
+++ b/src/Computation/Values/Constants/ConstantBool.cs
@@ -4,7 +4,7 @@ using Symbolica.Collection;
 
 namespace Symbolica.Computation.Values.Constants;
 
-internal sealed class ConstantBool : Bool, IConstantValue
+internal sealed record ConstantBool : Bool, IConstantValue
 {
     private readonly bool _value;
 

--- a/src/Computation/Values/Constants/ConstantDouble.cs
+++ b/src/Computation/Values/Constants/ConstantDouble.cs
@@ -7,7 +7,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values.Constants;
 
-internal sealed class ConstantDouble : Float, IConstantValue
+internal sealed record ConstantDouble : Float, IConstantValue
 {
     private readonly double _value;
 

--- a/src/Computation/Values/Constants/ConstantSigned.cs
+++ b/src/Computation/Values/Constants/ConstantSigned.cs
@@ -5,7 +5,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values.Constants;
 
-internal sealed class ConstantSigned : BitVector, IConstantValue
+internal sealed record ConstantSigned : BitVector, IConstantValue
 {
     private readonly BigInteger _value;
 

--- a/src/Computation/Values/Constants/ConstantSingle.cs
+++ b/src/Computation/Values/Constants/ConstantSingle.cs
@@ -7,7 +7,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values.Constants;
 
-internal sealed class ConstantSingle : Float, IConstantValue
+internal sealed record ConstantSingle : Float, IConstantValue
 {
     private readonly float _value;
 

--- a/src/Computation/Values/Constants/ConstantUnsigned.cs
+++ b/src/Computation/Values/Constants/ConstantUnsigned.cs
@@ -5,7 +5,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values.Constants;
 
-internal sealed class ConstantUnsigned : BitVector, IConstantValue
+internal sealed record ConstantUnsigned : BitVector, IConstantValue
 {
     private readonly BigInteger _value;
 

--- a/src/Computation/Values/Equal.cs
+++ b/src/Computation/Values/Equal.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class Equal : Bool
+internal sealed record Equal : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatAdd.cs
+++ b/src/Computation/Values/FloatAdd.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatAdd : Float
+internal sealed record FloatAdd : Float
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatCeiling.cs
+++ b/src/Computation/Values/FloatCeiling.cs
@@ -4,7 +4,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatCeiling : Float
+internal sealed record FloatCeiling : Float
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/FloatConvert.cs
+++ b/src/Computation/Values/FloatConvert.cs
@@ -4,7 +4,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatConvert : Float
+internal sealed record FloatConvert : Float
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/FloatDivide.cs
+++ b/src/Computation/Values/FloatDivide.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatDivide : Float
+internal sealed record FloatDivide : Float
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatEqual.cs
+++ b/src/Computation/Values/FloatEqual.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatEqual : Bool
+internal sealed record FloatEqual : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatFloor.cs
+++ b/src/Computation/Values/FloatFloor.cs
@@ -4,7 +4,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatFloor : Float
+internal sealed record FloatFloor : Float
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/FloatGreater.cs
+++ b/src/Computation/Values/FloatGreater.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatGreater : Bool
+internal sealed record FloatGreater : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatGreaterOrEqual.cs
+++ b/src/Computation/Values/FloatGreaterOrEqual.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatGreaterOrEqual : Bool
+internal sealed record FloatGreaterOrEqual : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatLess.cs
+++ b/src/Computation/Values/FloatLess.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatLess : Bool
+internal sealed record FloatLess : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatLessOrEqual.cs
+++ b/src/Computation/Values/FloatLessOrEqual.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatLessOrEqual : Bool
+internal sealed record FloatLessOrEqual : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatMultiply.cs
+++ b/src/Computation/Values/FloatMultiply.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatMultiply : Float
+internal sealed record FloatMultiply : Float
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatNegate.cs
+++ b/src/Computation/Values/FloatNegate.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatNegate : Float
+internal sealed record FloatNegate : Float
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/FloatPower.cs
+++ b/src/Computation/Values/FloatPower.cs
@@ -5,7 +5,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatPower : Float, IRealValue
+internal sealed record FloatPower : Float, IRealValue
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatRemainder.cs
+++ b/src/Computation/Values/FloatRemainder.cs
@@ -4,7 +4,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatRemainder : Float
+internal sealed record FloatRemainder : Float
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatSubtract.cs
+++ b/src/Computation/Values/FloatSubtract.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatSubtract : Float
+internal sealed record FloatSubtract : Float
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/FloatToSigned.cs
+++ b/src/Computation/Values/FloatToSigned.cs
@@ -5,7 +5,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatToSigned : BitVector
+internal sealed record FloatToSigned : BitVector
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/FloatToUnsigned.cs
+++ b/src/Computation/Values/FloatToUnsigned.cs
@@ -5,7 +5,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatToUnsigned : BitVector
+internal sealed record FloatToUnsigned : BitVector
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/FloatUnordered.cs
+++ b/src/Computation/Values/FloatUnordered.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class FloatUnordered : Bool
+internal sealed record FloatUnordered : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/LogicalAnd.cs
+++ b/src/Computation/Values/LogicalAnd.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class LogicalAnd : Bool
+internal sealed record LogicalAnd : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/LogicalNot.cs
+++ b/src/Computation/Values/LogicalNot.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class LogicalNot : Bool
+internal sealed record LogicalNot : Bool
 {
     private readonly Logical _value;
 
@@ -27,7 +27,7 @@ internal sealed class LogicalNot : Bool
         };
     }
 
-    private sealed class Logical : Bool
+    private sealed record Logical : Bool
     {
         private readonly IValue _value;
 

--- a/src/Computation/Values/LogicalOr.cs
+++ b/src/Computation/Values/LogicalOr.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class LogicalOr : Bool
+internal sealed record LogicalOr : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/LogicalShiftRight.cs
+++ b/src/Computation/Values/LogicalShiftRight.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class LogicalShiftRight : BitVector
+internal sealed record LogicalShiftRight : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/LogicalXor.cs
+++ b/src/Computation/Values/LogicalXor.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class LogicalXor : Bool
+internal sealed record LogicalXor : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/Multiply.cs
+++ b/src/Computation/Values/Multiply.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class Multiply : BitVector
+internal sealed record Multiply : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/Not.cs
+++ b/src/Computation/Values/Not.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class Not : BitVector
+internal sealed record Not : BitVector
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/Or.cs
+++ b/src/Computation/Values/Or.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class Or : BitVector
+internal sealed record Or : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/RealConvert.cs
+++ b/src/Computation/Values/RealConvert.cs
@@ -4,7 +4,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class RealConvert : Float, IRealValue
+internal sealed record RealConvert : Float, IRealValue
 {
     private readonly IRealValue _value;
 

--- a/src/Computation/Values/RealToSigned.cs
+++ b/src/Computation/Values/RealToSigned.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class RealToSigned : BitVector
+internal sealed record RealToSigned : BitVector
 {
     private readonly IRealValue _value;
 

--- a/src/Computation/Values/Select.cs
+++ b/src/Computation/Values/Select.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class Select : IValue
+internal sealed record Select : IValue
 {
     private readonly IValue _falseValue;
     private readonly IValue _predicate;

--- a/src/Computation/Values/ShiftLeft.cs
+++ b/src/Computation/Values/ShiftLeft.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class ShiftLeft : BitVector
+internal sealed record ShiftLeft : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/SignExtend.cs
+++ b/src/Computation/Values/SignExtend.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class SignExtend : BitVector
+internal sealed record SignExtend : BitVector
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/SignedDivide.cs
+++ b/src/Computation/Values/SignedDivide.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class SignedDivide : BitVector
+internal sealed record SignedDivide : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/SignedGreater.cs
+++ b/src/Computation/Values/SignedGreater.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class SignedGreater : Bool
+internal sealed record SignedGreater : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/SignedGreaterOrEqual.cs
+++ b/src/Computation/Values/SignedGreaterOrEqual.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class SignedGreaterOrEqual : Bool
+internal sealed record SignedGreaterOrEqual : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/SignedLess.cs
+++ b/src/Computation/Values/SignedLess.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class SignedLess : Bool
+internal sealed record SignedLess : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/SignedLessOrEqual.cs
+++ b/src/Computation/Values/SignedLessOrEqual.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class SignedLessOrEqual : Bool
+internal sealed record SignedLessOrEqual : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/SignedRemainder.cs
+++ b/src/Computation/Values/SignedRemainder.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class SignedRemainder : BitVector
+internal sealed record SignedRemainder : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/SignedToFloat.cs
+++ b/src/Computation/Values/SignedToFloat.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class SignedToFloat : Float
+internal sealed record SignedToFloat : Float
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/Subtract.cs
+++ b/src/Computation/Values/Subtract.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class Subtract : BitVector
+internal sealed record Subtract : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/Truncate.cs
+++ b/src/Computation/Values/Truncate.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class Truncate : BitVector
+internal sealed record Truncate : BitVector
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/UnsignedDivide.cs
+++ b/src/Computation/Values/UnsignedDivide.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class UnsignedDivide : BitVector
+internal sealed record UnsignedDivide : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/UnsignedGreater.cs
+++ b/src/Computation/Values/UnsignedGreater.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class UnsignedGreater : Bool
+internal sealed record UnsignedGreater : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/UnsignedGreaterOrEqual.cs
+++ b/src/Computation/Values/UnsignedGreaterOrEqual.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class UnsignedGreaterOrEqual : Bool
+internal sealed record UnsignedGreaterOrEqual : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/UnsignedLess.cs
+++ b/src/Computation/Values/UnsignedLess.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class UnsignedLess : Bool
+internal sealed record UnsignedLess : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/UnsignedLessOrEqual.cs
+++ b/src/Computation/Values/UnsignedLessOrEqual.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class UnsignedLessOrEqual : Bool
+internal sealed record UnsignedLessOrEqual : Bool
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/UnsignedRemainder.cs
+++ b/src/Computation/Values/UnsignedRemainder.cs
@@ -2,7 +2,7 @@
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class UnsignedRemainder : BitVector
+internal sealed record UnsignedRemainder : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/UnsignedToFloat.cs
+++ b/src/Computation/Values/UnsignedToFloat.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class UnsignedToFloat : Float
+internal sealed record UnsignedToFloat : Float
 {
     private readonly IValue _value;
 

--- a/src/Computation/Values/Write.cs
+++ b/src/Computation/Values/Write.cs
@@ -6,7 +6,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class Write : BitVector
+internal sealed record Write : BitVector
 {
     private readonly IValue _writeBuffer;
     private readonly IValue _writeMask;

--- a/src/Computation/Values/Xor.cs
+++ b/src/Computation/Values/Xor.cs
@@ -3,7 +3,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class Xor : BitVector
+internal sealed record Xor : BitVector
 {
     private readonly IValue _left;
     private readonly IValue _right;

--- a/src/Computation/Values/ZeroExtend.cs
+++ b/src/Computation/Values/ZeroExtend.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation.Values;
 
-internal sealed class ZeroExtend : BitVector
+internal sealed record ZeroExtend : BitVector
 {
     private readonly IValue _value;
 

--- a/tests/Computation.Tests/SymbolicDouble.cs
+++ b/tests/Computation.Tests/SymbolicDouble.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation;
 
-internal sealed class SymbolicDouble : Float
+internal sealed record SymbolicDouble : Float
 {
     private readonly double _value;
 

--- a/tests/Computation.Tests/SymbolicSingle.cs
+++ b/tests/Computation.Tests/SymbolicSingle.cs
@@ -3,7 +3,7 @@ using Symbolica.Expression;
 
 namespace Symbolica.Computation;
 
-internal sealed class SymbolicSingle : Float
+internal sealed record SymbolicSingle : Float
 {
     private readonly float _value;
 

--- a/tests/Computation.Tests/SymbolicUnsigned.cs
+++ b/tests/Computation.Tests/SymbolicUnsigned.cs
@@ -4,7 +4,7 @@ using Symbolica.Computation.Values.Constants;
 
 namespace Symbolica.Computation;
 
-internal sealed class SymbolicUnsigned : BitVector
+internal sealed record SymbolicUnsigned : BitVector
 {
     private readonly BigInteger _value;
 


### PR DESCRIPTION
I've decided that I think structural equality of `IValue` implementations is both useful and correct. As a first step towards that I'm proposing that we make all of them a `record` instead of a `class`. 

Also, if this is going to cause conflicts with any of your other then let me know and won't merge until your stuff is in, so that I can rebase on to yours.